### PR TITLE
Custom license suppliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 ### Sample Configuration
 
+**Configuration in POM**
 ```xml
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
@@ -45,6 +46,27 @@
     </executions>
 </plugin>
 ```
+**Configuration external to POM**
+
+This is the recommended approach for larger projects with many licenses, in order to not pollute the pom.
+Please see `TextFileSupplier` javadoc for details.
+
+```xml
+<configuration>
+    <rules>
+        <myCustomRule implementation="io.github.patrickpilch.dependencylicensechecker.plugin.enforcer.LicenseEnforcerRule">
+            <licenseSupplier implementation="io.github.patrickpilch.dependencylicensechecker.suppliers.TextFileSupplier">
+                <filePath>licenses.txt</filePath>
+            </licenseSupplier>
+        </myCustomRule>
+    </rules>
+</configuration>
+```
+
+**Note**
+- License names are leading/trailing whitespace and case sensitive.
+- Both internal and external configurations will be respected if defined simultaneously.
+
 
 ### Sample Output
 ```
@@ -59,6 +81,11 @@ patrick.test.sandbox:Sandbox:jar:1.0-SNAPSHOT
 [INFO] BUILD FAILURE
 [INFO] ------------------------------------------------------------------------
 ```
+
+## Limitations
+
+This plugin only inspects project dependencies, e.g. not build and reporting plugins. It is a future goal to support
+this, but in the meantime a mitigation is to place the plugin into the `<dependencies>` section to be scanned.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,3 @@ _Why no regular expression support for licenses?_
 
 This was another strategic choice made to address the risk of writing an overly permissive regex that would allow a new
 license to sneak into the permitted list.
-
-## TODOs before initial release
-- Create LicenseWhitelistProvider and ExclusionProvider interfaces and default implementation of file-based reading.
-- Add support for scanning plugins, and not only artifacts in `<dependencies>`

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/it/projects/license-file-misconfigured/invoker.properties
+++ b/src/it/projects/license-file-misconfigured/invoker.properties
@@ -1,0 +1,17 @@
+#
+#    Copyright 2016 Patrick Pilch. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+invoker.buildResult = failure

--- a/src/it/projects/license-file-misconfigured/pom.xml
+++ b/src/it/projects/license-file-misconfigured/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2016 Patrick Pilch. All Rights Reserved.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.patrickpilch.dependencylicensechecker.integrationtests</groupId>
+    <artifactId>license-file-misconfigured</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <licenses>
+        <license>
+            <name>Valid-License v1.3.2</name>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.patrickpilch.dependencylicensechecker</groupId>
+                        <artifactId>dependency-license-checker</artifactId>
+                        <version>@pom.version@</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <myCustomRule implementation="io.github.patrickpilch.dependencylicensechecker.plugin.enforcer.LicenseEnforcerRule">
+                                    <licenseSupplier implementation="io.github.patrickpilch.dependencylicensechecker.suppliers.TextFileSupplier">
+                                        <filePath>licenses.txt</filePath>
+                                    </licenseSupplier>
+                                </myCustomRule>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/license-file-misconfigured/verify.groovy
+++ b/src/it/projects/license-file-misconfigured/verify.groovy
@@ -1,0 +1,19 @@
+/*
+ *    Copyright 2016 Patrick Pilch. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+def logFile = new File(basedir, 'build.log')
+assert logFile.exists()
+assert logFile.text.contains(/suppliers.SupplierException: java.io.FileNotFoundException/)

--- a/src/it/projects/license-file/invoker.properties
+++ b/src/it/projects/license-file/invoker.properties
@@ -1,0 +1,17 @@
+#
+#    Copyright 2016 Patrick Pilch. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+invoker.buildResult = success

--- a/src/it/projects/license-file/licenses.txt
+++ b/src/it/projects/license-file/licenses.txt
@@ -1,0 +1,2 @@
+
+Valid-License v1.3.2

--- a/src/it/projects/license-file/pom.xml
+++ b/src/it/projects/license-file/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~    Copyright 2016 Patrick Pilch. All Rights Reserved.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.patrickpilch.dependencylicensechecker.integrationtests</groupId>
+    <artifactId>license-file</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <licenses>
+        <license>
+            <name>Valid-License v1.3.2</name>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.patrickpilch.dependencylicensechecker</groupId>
+                        <artifactId>dependency-license-checker</artifactId>
+                        <version>@pom.version@</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <myCustomRule implementation="io.github.patrickpilch.dependencylicensechecker.plugin.enforcer.LicenseEnforcerRule">
+                                    <licenseSupplier implementation="io.github.patrickpilch.dependencylicensechecker.suppliers.TextFileSupplier">
+                                        <filePath>licenses.txt</filePath>
+                                    </licenseSupplier>
+                                </myCustomRule>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/io/github/patrickpilch/dependencylicensechecker/DependencyChecker.java
+++ b/src/main/java/io/github/patrickpilch/dependencylicensechecker/DependencyChecker.java
@@ -84,7 +84,7 @@ public class DependencyChecker {
             } else {
                 for (final License license : licenses) {
                     log.debug("Inspecting license - " + license.getName());
-                    if (!whitelistedLicenses.contains(license.getName().trim().toLowerCase())) {
+                    if (!whitelistedLicenses.contains(license.getName())) {
                         throw new LicenseNotAllowedException(dependency, license);
                     } else if (log.isDebugEnabled()) {
                         log.debug("\"" + dependency.getArtifact().getId() + "\" with license \"" + license.getName() +

--- a/src/main/java/io/github/patrickpilch/dependencylicensechecker/suppliers/SupplierException.java
+++ b/src/main/java/io/github/patrickpilch/dependencylicensechecker/suppliers/SupplierException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Patrick Pilch. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.patrickpilch.dependencylicensechecker.suppliers;
+
+/**
+ * General Supplier related run-time exception
+ */
+class SupplierException extends RuntimeException {
+    /**
+     * {@inheritDoc}
+     */
+    SupplierException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    SupplierException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/io/github/patrickpilch/dependencylicensechecker/suppliers/TextFileSupplier.java
+++ b/src/main/java/io/github/patrickpilch/dependencylicensechecker/suppliers/TextFileSupplier.java
@@ -1,0 +1,83 @@
+/*
+ *    Copyright 2016 Patrick Pilch. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.github.patrickpilch.dependencylicensechecker.suppliers;
+
+import java.io.*;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Reads in an input file and returns each line in the file as an element in the output list.
+ */
+public class TextFileSupplier implements Supplier<List<String>> {
+    ///// Mojo Parameters /////
+    @SuppressWarnings("unused")
+    private String filePath;
+
+    private InputStream textFileInputStream;
+    private final AtomicReference<List<String>> lines = new AtomicReference<>();
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public TextFileSupplier() {
+        // Required for Mojo to instantiate this when parsing the xml configuration
+    }
+
+    TextFileSupplier(InputStream textFileInputStream) {
+        this.textFileInputStream = textFileInputStream;
+    }
+
+    @Override
+    public List<String> get() {
+        if (lines.get() == null) {
+            synchronized(this) {
+                if (lines.get() == null) {
+                    initializeInputStream();
+                    lines.getAndSet(readNonEmptyLines(textFileInputStream));
+                }
+            }
+        }
+        return lines.get();
+    }
+
+    private void initializeInputStream() {
+        try {
+            if (textFileInputStream == null) {
+                if (filePath == null) {
+                    throw new SupplierException("Must provide text file");
+                } else {
+                    textFileInputStream = new FileInputStream(filePath);
+                }
+            }
+        } catch (FileNotFoundException e) {
+            throw new SupplierException(e);
+        }
+    }
+
+    /**
+     * Returns non empty lines of a file while preserving whitespace of populated lines.
+     * @param fileInputStream Input stream of the file to read
+     * @return A list of strings representing the non-empty lines in the file.
+     */
+    private static List<String> readNonEmptyLines(final InputStream fileInputStream) {
+        return new BufferedReader(new InputStreamReader(fileInputStream))
+                .lines()
+                .filter(s -> !s.trim().isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/io/github/patrickpilch/dependencylicensechecker/suppliers/TextFileSupplierTest.java
+++ b/src/test/java/io/github/patrickpilch/dependencylicensechecker/suppliers/TextFileSupplierTest.java
@@ -1,0 +1,40 @@
+/*
+ *    Copyright 2016 Patrick Pilch. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package io.github.patrickpilch.dependencylicensechecker.suppliers;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+public class TextFileSupplierTest {
+    @Test
+    public void getWithInjectedStream() throws Exception {
+        final TextFileSupplier textFileSupplier = new TextFileSupplier(
+                TextFileSupplierTest.class.getResourceAsStream("test.txt"));
+        final List<String> licenses = textFileSupplier.get();
+        assertThat(licenses, contains("License One", "  License Two  ", "License Three"));
+    }
+
+    @Test(expected = SupplierException.class)
+    public void testWithNoFilePath() {
+        final TextFileSupplier textFileSupplier = new TextFileSupplier();
+        textFileSupplier.get();
+    }
+}

--- a/src/test/resources/io/github/patrickpilch/dependencylicensechecker/suppliers/test.txt
+++ b/src/test/resources/io/github/patrickpilch/dependencylicensechecker/suppliers/test.txt
@@ -1,0 +1,5 @@
+License One
+  License Two  
+
+License Three
+


### PR DESCRIPTION
Adding support for custom license suppliers to externalize configuration of allowed licenses. 
Included an implementation that reads basic new-line separated input files.
